### PR TITLE
Fix: To make it work with @types/node v.12.7

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ export interface AudioOptions {
  * The function signature of the callbacks to various `AudioInput` and
  * `AudioOutput` methods.
  */
-export type AudioCallback = () => void;
+export type AudioCallback = (error?: Error | null | undefined) => void;
 
 /**
  * AudioInput is a readable stream that records audio from the given device


### PR DESCRIPTION
Right now using your library v0.4.9 with latest @types/node v12.7.2 there is compilation error for ts files with wrong type definition for `node-portaudio` lib:

```
node_modules/node-portaudio/index.d.ts:27:5 - error TS2416: Property 'write' in type 'AudioOutput' is not assignable to the same property in base type 'Writable'.
  Type '(chunk: any, encoding?: any, cb?: AudioCallback) => boolean' is not assignable to type '{ (chunk: any, cb?: (error: Error) => void): boolean; (chunk: any, encoding: string, cb?: (error: Error) => void): boolean; }'.
    Types of parameters 'cb' and 'cb' are incompatible.

27     write(chunk: any, encoding?: any, cb?: AudioCallback): boolean;
       ~~~~~


Found 1 error.
```

Fixing `AudioCallback` will resolve this issue.